### PR TITLE
Tidy up and expand implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented below. The format is base
 
 ## [Unreleased]
 
+- Changed: Switch to Zeitwerk for loading internally
+
 ## [0.1.1] - 2022-10-22
 
 - Changed: pinned dependencies to major versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented below. The format is base
 
 ## [Unreleased]
 
+- Added: `Tsclient::ApiFinder` handles finding the api in known places
 - Changed: Switch to Zeitwerk for loading internally
 
 ## [0.1.1] - 2022-10-22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     tsclient (0.1.1)
       json (~> 2.5)
       values (~> 1.8)
+      zeitwerk (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
@@ -39,6 +40,7 @@ GEM
       rubocop-performance (= 1.14.3)
     unicode-display_width (2.3.0)
     values (1.8.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,10 @@ GEM
     json (2.6.2)
     minitest (5.16.3)
     parallel (1.22.1)
-    parser (3.1.2.1)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.0)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ```ruby
 client = Tsclient.default_client
+# => #<Tsclient::Client …>
 
-client.tailscale_ips
+tsips = client.tailscale_ips
 # => ["100.100.100.1", "fd7a:115c:a1e0::1"]
 
-client.whois "100.100.100.1"
-# => => #<Tsclient::Profile identifier="bob.bobbity@example.com", name="Bob Bobbity", profile_pic_url="www.google.com/images/errors/robot.png", human=true>
+client.whois tsips.first
+# => #<Tsclient::Profile identifier="bob.bobbity@example.com", name="Bob Bobbity", profile_pic_url="https://www.google.com/images/errors/robot.png", human=true>
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Client library wrapping the [Tailscale localapi][localapi]. This lets you do things like find out the identity of another machine talking to you on the tailnet, or interrogate the current machine's info.
 
+Tsclient attempts to figure out the correct url for your [Tailscale localapi][localapi] based on what Operating System you are running. On macOS it connects over localhost to the randomly assigned port with the randomly generated password, provided you're running `Tailscale.app` as the same user as the ruby process. On linux it assumes the tailscaled socket is in the default location in `/run`.
+
+If you're running a custom setup and need to tell `Tsclient` where your `tailscaled` socket is, you can either set `TSCLIENT_API_URI` to either a `http://` or `unix://` URI, or programatically you can pass it as an argument when creating an instance of `Tsclient::Client`.
+
 [localapi]: https://github.com/tailscale/tailscale/blob/main/ipn/localapi/localapi.go
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ client.whois tsips.first
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/tsclient.rb
+++ b/lib/tsclient.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "tsclient/client"
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.setup
 
 module Tsclient
   def self.default_client
@@ -24,3 +26,5 @@ module Tsclient
     @default_client = Client.new(uri: uri)
   end
 end
+
+loader.eager_load

--- a/lib/tsclient.rb
+++ b/lib/tsclient.rb
@@ -5,7 +5,7 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module Tsclient
-  def self.default_client(api_finder: FindApiUri.new)
+  def self.default_client(api_finder: ApiFinder.new)
     return @default_client if defined?(@default_client)
 
     if (uri = api_finder.call)

--- a/lib/tsclient.rb
+++ b/lib/tsclient.rb
@@ -5,25 +5,14 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module Tsclient
-  def self.default_client
+  def self.default_client(api_finder: FindApiUri.new)
     return @default_client if defined?(@default_client)
 
-    # Attempt to setup the default client from various known strategies
-    # Envariables override everything
-    uri = if ENV.key?("TS_LOCALAPI_PORT")
-      URI("http://:#{ENV["TS_LOCALAPI_KEY"]}@localhost:#{ENV["TS_LOCALAPI_PORT"]}")
-
-    # Running on macOS, need to find api deets from filesystem
-    elsif RUBY_PLATFORM["darwin"]
-      tsfile = Pathname.glob("#{ENV["HOME"]}/Library/Group Containers/*.io.tailscale.ipn.macos/sameuserproof-*-*").first
-      _, port, password = tsfile.basename.to_s.split("-", 3)
-      URI("http://:#{password}@localhost:#{port}")
-    # Throw our hands in the air, we just don't ~~care~~ know
+    if (uri = api_finder.call)
+      @default_client = Client.new(uri: uri)
     else
-      raise NotImplemented, "Can't figure out where localapi is"
+      raise Error.new("Could not find localapi on this machine")
     end
-
-    @default_client = Client.new(uri: uri)
   end
 end
 

--- a/lib/tsclient/api_finder.rb
+++ b/lib/tsclient/api_finder.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
+require "uri"
+
 module Tsclient
   class ApiFinder
     def call(env: ENV, ruby_platform: RUBY_PLATFORM)
       if env.key?("TSCLIENT_API_URI")
-        env.fetch("TSCLIENT_API_URI")
+        URI(env.fetch("TSCLIENT_API_URI"))
       elsif ruby_platform["darwin"]
         # Running on macOS, api port & auth are in a specific filename
         if (tsfile = Pathname.glob("#{env["HOME"]}/Library/Group Containers/*.io.tailscale.ipn.macos/sameuserproof-*-*").first)
           _, port, password = tsfile.basename.to_s.split("-", 3)
-          "http://:#{password}@localhost:#{port}"
+          URI("http://:#{password}@localhost:#{port}")
         end
       end
     end

--- a/lib/tsclient/api_finder.rb
+++ b/lib/tsclient/api_finder.rb
@@ -1,0 +1,15 @@
+module Tsclient
+  class ApiFinder
+    def call(env: ENV, ruby_platform: RUBY_PLATFORM)
+      if env.key?("TSCLIENT_API_URI")
+        env.fetch("TSCLIENT_API_URI")
+      elsif ruby_platform["darwin"]
+        # Running on macOS, api port & auth are in a specific filename
+        if (tsfile = Pathname.glob("#{env["HOME"]}/Library/Group Containers/*.io.tailscale.ipn.macos/sameuserproof-*-*").first)
+          _, port, password = tsfile.basename.to_s.split("-", 3)
+          "http://:#{password}@localhost:#{port}"
+        end
+      end
+    end
+  end
+end

--- a/lib/tsclient/client.rb
+++ b/lib/tsclient/client.rb
@@ -3,9 +3,6 @@
 require "net/http"
 require "json"
 
-require_relative "./result"
-require_relative "./profile"
-
 module Tsclient
   class Client
     def initialize(uri:)

--- a/lib/tsclient/error.rb
+++ b/lib/tsclient/error.rb
@@ -1,0 +1,3 @@
+module Tsclient
+  Error = Class.new(StandardError)
+end

--- a/spec/tsclient/api_finder_spec.rb
+++ b/spec/tsclient/api_finder_spec.rb
@@ -8,12 +8,12 @@ describe Tsclient::ApiFinder do
 
       uri = Tsclient::ApiFinder.new.call(env: fake_env)
 
-      _(uri).must_equal(fake_env["TSCLIENT_API_URI"])
+      _(uri).must_equal(URI(fake_env["TSCLIENT_API_URI"]))
     end
   end
 
   describe "on macOS with Tailscale.app running" do
-    it "returns http uri with auth and port" do
+    it "returns URI::HTTP with auth and port" do
       # Setup a home dir with the correct file path we expect on macOS to find port/password in filename
       fake_home = Dir.mktmpdir(%w[tsclient spec]).tap do |home|
         dir = Pathname.new(home).join("Library", "Group Containers", "#{SecureRandom.alphanumeric(5)}.io.tailscale.ipn.macos")
@@ -24,7 +24,7 @@ describe Tsclient::ApiFinder do
 
       uri = Tsclient::ApiFinder.new.call(env: fake_env, ruby_platform: "arm64-darwin21")
 
-      _(uri).must_equal("http://:totes1sekrit@localhost:1337")
+      _(uri).must_equal(URI("http://:totes1sekrit@localhost:1337"))
     ensure
       FileUtils.remove_entry(fake_home) if defined?(fake_home)
     end

--- a/spec/tsclient/api_finder_spec.rb
+++ b/spec/tsclient/api_finder_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe Tsclient::ApiFinder do
+  describe "with TSCLIENT_API_URI set" do
+    it "returns that as URI" do
+      # ENV is string keyed
+      fake_env = {"TSCLIENT_API_URI" => "unix:///tmp/tailscaled.sock"}
+
+      uri = Tsclient::ApiFinder.new.call(env: fake_env)
+
+      _(uri).must_equal(fake_env["TSCLIENT_API_URI"])
+    end
+  end
+
+  describe "on macOS with Tailscale.app running" do
+    it "returns http uri with auth and port" do
+      # Setup a home dir with the correct file path we expect on macOS to find port/password in filename
+      fake_home = Dir.mktmpdir(%w[tsclient spec]).tap do |home|
+        dir = Pathname.new(home).join("Library", "Group Containers", "#{SecureRandom.alphanumeric(5)}.io.tailscale.ipn.macos")
+        dir.mkpath
+        dir.join("sameuserproof-1337-totes1sekrit").write("")
+      end
+      fake_env = {"HOME" => fake_home.to_s}
+
+      uri = Tsclient::ApiFinder.new.call(env: fake_env, ruby_platform: "arm64-darwin21")
+
+      _(uri).must_equal("http://:totes1sekrit@localhost:1337")
+    ensure
+      FileUtils.remove_entry(fake_home) if defined?(fake_home)
+    end
+  end
+
+  describe "on macOS without Tailscale.app running" do
+    it "returns no uri" do
+      fake_home = Dir.mktmpdir(%w[tsclient spec])
+      fake_env = {"HOME" => fake_home}
+
+      uri = Tsclient::ApiFinder.new.call(env: fake_env, ruby_platform: "arm64-darwin21")
+
+      _(uri).must_be_nil
+    end
+  end
+
+  # describe "on linux with default socket present"
+  # describe "on linux with default socket missing"
+
+  describe "when unable to find api" do
+    it "returns nil" do
+      # Empty env means no TSCLIENT_API_URI, no finding macOS file
+      uri = Tsclient::ApiFinder.new.call(env: {})
+
+      _(uri).must_be_nil
+    end
+  end
+end

--- a/spec/tsclient_spec.rb
+++ b/spec/tsclient_spec.rb
@@ -6,4 +6,34 @@ describe Tsclient do
   it "has a version number" do
     value(Tsclient::VERSION).wont_be_nil
   end
+
+  describe ".default_client" do
+    # Revert memoization between specs
+    after do
+      Tsclient.__send__ :remove_instance_variable, :@default_client if Tsclient.instance_eval { defined?(@default_client) }
+    end
+
+    describe "with found api" do
+      subject { Tsclient.default_client(api_finder: -> { "unix:///run/tailscale/tailscaled.sock" }) }
+
+      it "returns client" do
+        value(subject).must_be_kind_of(Tsclient::Client)
+      end
+
+      it "memoizes the created client" do
+        client = subject
+        client2 = subject
+
+        value(client.object_id).must_equal(client2.object_id)
+      end
+    end
+
+    describe "without finding api" do
+      it "raises error" do
+        assert_raises {
+          Tsclient.default_client(api_finder: -> {})
+        }
+      end
+    end
+  end
 end

--- a/tsclient.gemspec
+++ b/tsclient.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json", "~> 2.5"
   spec.add_dependency "values", "~> 1.8"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
- [x] Extract URL finding for tailscaled localapi
- [x] Add base error class
- [x] Load gem internals with Zeitwerk (lovely and easy to use)
- [x] Add specs for `Tsclient.default_client` behaviour
- [x] Add specs for `Tsclient::ApiFinder` behaviour from `ENV`
- [x] Add specs for `Tsclient::ApiFinder` behaviour on macOS
- [ ] Add specs for `Tsclient::ApiFinder` behaviour on linux
