### PR TITLE
Fix localapi discovery on recent versions of macOS Tailscale

### DIFF
--- a/lib/tsclient/api_finder.rb
+++ b/lib/tsclient/api_finder.rb
@@ -9,6 +9,11 @@ module Tsclient
         URI(env.fetch("TSCLIENT_API_URI"))
       elsif ruby_platform["darwin"]
         # Running on macOS, api port & auth are in a specific filename
+        if (tsfile = Pathname.glob("/Library/Tailscale/sameuserproof-*").first)
+          port = tsfile.basename.to_s.split('-').last
+          password = File.read(tsfile).chomp
+          return URI("http://:#{password}@localhost:#{port}")
+        end
         if (tsfile = Pathname.glob("#{env["HOME"]}/Library/Group Containers/*.io.tailscale.ipn.macos/sameuserproof-*-*").first)
           _, port, password = tsfile.basename.to_s.split("-", 3)
           URI("http://:#{password}@localhost:#{port}")

--- a/lib/tsclient/version.rb
+++ b/lib/tsclient/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tsclient
-  VERSION = "0.1.2"
+  VERSION = "0.1.1"
 end

--- a/lib/tsclient/version.rb
+++ b/lib/tsclient/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tsclient
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
tailscale changed the path at some point... this broke tsclient on my mac :-(
now it's not broke!